### PR TITLE
Replaced deprecated each() in Cache/Backend

### DIFF
--- a/library/Zend/Cache/Backend.php
+++ b/library/Zend/Cache/Backend.php
@@ -76,14 +76,18 @@ class Zend_Cache_Backend
     public function setDirectives($directives)
     {
         if (!is_array($directives)) Zend_Cache::throwException('Directives parameter must be an array');
-        while (list($name, $value) = each($directives)) {
-            if (!is_string($name)) {
-                Zend_Cache::throwException("Incorrect option name : $name");
-            }
-            $name = strtolower($name);
-            if (array_key_exists($name, $this->_directives)) {
-                $this->_directives[$name] = $value;
-            }
+        foreach($directives as $name => $value) 
+        {
+          //list($name, $value) = $directive; 
+          if (!is_string($name)) 
+          {
+              Zend_Cache::throwException("Incorrect option name : $name");
+          }
+          $name = strtolower($name);
+          if (array_key_exists($name, $this->_directives)) 
+          {
+              $this->_directives[$name] = $value;
+          }
 
         }
 


### PR DESCRIPTION
each() function is deprecated in php 7.2 - eliminated necessary calls in zend framework for mone20
